### PR TITLE
Feat/dev

### DIFF
--- a/internal/chat/controller.go
+++ b/internal/chat/controller.go
@@ -14,10 +14,10 @@ import (
 
 // Controller exposes handlers for GPT API.
 type Controller struct {
-	service *Service
+	service Service
 }
 
-func NewController(s *Service) *Controller {
+func NewController(s Service) *Controller {
 	return &Controller{
 		service: s,
 	}

--- a/internal/chat/dev.go
+++ b/internal/chat/dev.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"context"
+	"time"
 
 	"ailingo/internal/models"
 )
@@ -18,6 +19,8 @@ func NewDevService() Service {
 // GenerateSentence generates a fake example sentence.
 // If the phrase is equal to fail an example unsuccessful result will be returned.
 func (ds *DevService) GenerateSentence(ctx context.Context, word models.Word) (*GenerationResult, error) {
+	time.Sleep(time.Second * 3)
+
 	if word.Phrase == "fail" {
 		return &GenerationResult{
 			Success: false,

--- a/internal/chat/dev.go
+++ b/internal/chat/dev.go
@@ -1,0 +1,32 @@
+package chat
+
+import (
+	"context"
+
+	"ailingo/internal/models"
+)
+
+// DevService can be used when the backend is running in development mode.
+// It does not make real requests to OpenAI API. Returns a fake response instead
+// to save money.
+type DevService struct{}
+
+func NewDevService() Service {
+	return &DevService{}
+}
+
+// GenerateSentence generates a fake example sentence.
+// If the phrase is equal to fail an example unsuccessful result will be returned.
+func (ds *DevService) GenerateSentence(ctx context.Context, word models.Word) (*GenerationResult, error) {
+	if word.Phrase == "fail" {
+		return &GenerationResult{
+			Success: false,
+			Reason:  "This is an example reason why I have failed",
+		}, nil
+	}
+
+	return &GenerationResult{
+		Success:  true,
+		Sentence: "Why have you been farting around here all this time?",
+	}, nil
+}

--- a/internal/chat/service.go
+++ b/internal/chat/service.go
@@ -23,13 +23,17 @@ var (
 //go:embed prompts/sentence_generator_v2.prompt
 var sentenceGeneratorSystem string
 
-// Service expose features related with OpenAI's chat completion API.
-type Service struct {
-	chatClient *openai.ChatClient
+type Service interface {
+	GenerateSentence(ctx context.Context, word models.Word) (*GenerationResult, error)
 }
 
-func NewService(chatClient *openai.ChatClient) *Service {
-	return &Service{
+// ServiceImpl expose features related with OpenAI's chat completion API.
+type ServiceImpl struct {
+	chatClient *openai.ChatClientImpl
+}
+
+func NewService(chatClient *openai.ChatClientImpl) Service {
+	return &ServiceImpl{
 		chatClient: chatClient,
 	}
 }
@@ -42,7 +46,7 @@ type GenerationResult struct {
 }
 
 // GenerateSentence requests a new chat completion with Sentence Generator Persona prompt.
-func (s *Service) GenerateSentence(ctx context.Context, word models.Word) (*GenerationResult, error) {
+func (s *ServiceImpl) GenerateSentence(ctx context.Context, word models.Word) (*GenerationResult, error) {
 	completion, err := s.chatClient.RequestCompletion(ctx, openai.CompletionChat{
 		Model: "gpt-3.5-turbo",
 		Messages: []openai.Message{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"flag"
 	"fmt"
 	"os"
 
@@ -15,10 +16,14 @@ type Config struct {
 	TlsCert     string
 	TlsKey      string
 	DSN         string
+	Prod        bool
 }
 
 // Load loads Config, using .env as the config source, and returns it.
 func Load() (*Config, error) {
+	prodFlag := flag.Bool("prod", false, "run server in production configuration")
+	flag.Parse()
+
 	if err := godotenv.Load(".env"); err != nil {
 		return nil, fmt.Errorf("failed to load .env: %w", err)
 	}
@@ -30,5 +35,6 @@ func Load() (*Config, error) {
 		TlsCert:     os.Getenv("TLS_CERT"),
 		TlsKey:      os.Getenv("TLS_KEY"),
 		DSN:         os.Getenv("DSN"),
+		Prod:        *prodFlag,
 	}, nil
 }

--- a/internal/translation/controller.go
+++ b/internal/translation/controller.go
@@ -9,17 +9,16 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"ailingo/pkg/apiutil"
-	"ailingo/pkg/deepl"
 )
 
 // Controller exposes handlers for translation API.
 type Controller struct {
-	deeplClient *deepl.Client
+	translator Translator
 }
 
-func NewController(deeplClient *deepl.Client) *Controller {
+func NewController(translator Translator) *Controller {
 	return &Controller{
-		deeplClient: deeplClient,
+		translator: translator,
 	}
 }
 
@@ -42,7 +41,7 @@ func (c *Controller) Translate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	t, err := c.deeplClient.Translate(ctx, phrase)
+	t, err := c.translator.Translate(ctx, phrase)
 	if err != nil {
 		apiutil.Err(w, http.StatusInternalServerError, err)
 		return

--- a/internal/translation/dev.go
+++ b/internal/translation/dev.go
@@ -1,6 +1,9 @@
 package translation
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // DevTranslator stubs DeepL client functionality in order to save API calls during app development.
 type DevTranslator struct{}
@@ -10,5 +13,6 @@ func NewDevTranslator() Translator {
 }
 
 func (dt *DevTranslator) Translate(ctx context.Context, text string) (string, error) {
-	return "Development", nil
+	time.Sleep(time.Second * 3)
+	return "development", nil
 }

--- a/internal/translation/dev.go
+++ b/internal/translation/dev.go
@@ -1,0 +1,14 @@
+package translation
+
+import "context"
+
+// DevTranslator stubs DeepL client functionality in order to save API calls during app development.
+type DevTranslator struct{}
+
+func NewDevTranslator() Translator {
+	return &DevTranslator{}
+}
+
+func (dt *DevTranslator) Translate(ctx context.Context, text string) (string, error) {
+	return "Development", nil
+}

--- a/internal/translation/translator.go
+++ b/internal/translation/translator.go
@@ -1,0 +1,7 @@
+package translation
+
+import "context"
+
+type Translator interface {
+	Translate(ctx context.Context, text string) (string, error)
+}


### PR DESCRIPTION
- Introduced `--prod` flag that runs the server in production environment (runs in dev by default)
- Changed translate endpoint so that it accepts a json body with `"phrase"` field instead of a `phrase` query param